### PR TITLE
feat(lightbulb): get rid of lspsaga lightbulb temp (not exactly stop …

### DIFF
--- a/lua/weicheng/plugins/lsp/lspsaga.lua
+++ b/lua/weicheng/plugins/lsp/lspsaga.lua
@@ -1,18 +1,23 @@
 local saga_setup, saga = pcall(require, "lspsaga")
 if not saga_setup then
-  return
+	return
 end
 
 saga.setup({
-  -- keybinds for navigation in lspsaga window
-  scroll_preview = { scroll_down = "<C-f>", scroll_up = "<C-b>" },
-  -- use enter to open file with definition preview
-  definition = {
-    edit = "<CR>",
-  },
-  ui = {
-    colors = {
-      normal_bg = "#022746",
-    },
-  },
+	-- keybinds for navigation in lspsaga window
+	scroll_preview = { scroll_down = "<C-f>", scroll_up = "<C-b>" },
+	-- use enter to open file with definition preview
+	definition = {
+		edit = "<CR>",
+	},
+	ui = {
+		code_action = "",
+		colors = {
+			normal_bg = "#022746",
+		},
+	},
+	lightbulb = {
+		enabled = false,
+		sign = true,
+	},
 })


### PR DESCRIPTION
## Try to turn off lightbulb code action
What I just did is only make the ui.code_action to be "". Not really turn it off.
```lua
        -- lspsaga.lua
	ui = {
	        -- works for disappearing
		code_action = "",
		colors = {
			normal_bg = "#022746",
		},
	},
	-- not works at all
	lightbulb = {
		enabled = false,
		sign = true,
	},
```